### PR TITLE
Refactor flake8 fixes

### DIFF
--- a/set1/challenge01/tests/tests_encode.py
+++ b/set1/challenge01/tests/tests_encode.py
@@ -1,7 +1,7 @@
 import binascii
 import unittest
 
-from set1.challenge01.encode import *
+from set1.challenge01.encode import hextob64, b64tohex
 
 
 class TestEncode(unittest.TestCase):

--- a/set1/challenge02/tests/tests_fixed_xor.py
+++ b/set1/challenge02/tests/tests_fixed_xor.py
@@ -1,6 +1,6 @@
 import unittest
 
-from set1.challenge02.fixed_xor import *
+from set1.challenge02.fixed_xor import xor
 
 
 class TestFixedXOR(unittest.TestCase):

--- a/set1/challenge03/tests/tests_break_single_xor.py
+++ b/set1/challenge03/tests/tests_break_single_xor.py
@@ -1,6 +1,7 @@
 import unittest
 
-from set1.challenge03.break_single_xor import *
+from set1.challenge03.break_single_xor import ENGLISH_LETTER_FREQ, \
+    break_single_xor, freq_score
 
 
 class TestFreqScore(unittest.TestCase):

--- a/set1/challenge03/tests/tests_single_xor.py
+++ b/set1/challenge03/tests/tests_single_xor.py
@@ -1,6 +1,6 @@
 import unittest
 
-from set1.challenge03.single_xor import *
+from set1.challenge03.single_xor import single_xor
 
 
 class TestSingleXOR(unittest.TestCase):

--- a/set1/challenge05/tests/tests_repeat_xor.py
+++ b/set1/challenge05/tests/tests_repeat_xor.py
@@ -1,6 +1,6 @@
 import unittest
 
-from set1.challenge05.repeat_xor import *
+from set1.challenge05.repeat_xor import repeat_xor
 
 
 class TestRepeatXOR(unittest.TestCase):

--- a/set1/challenge06/tests/tests_break_repeat_xor.py
+++ b/set1/challenge06/tests/tests_break_repeat_xor.py
@@ -4,11 +4,11 @@ import pathlib
 import unittest
 
 from set1.challenge06.break_repeat_xor import \
-    break_repeat_xor
+    break_repeat_xor, \
     build_transposed, \
     find_keysize, \
     hamming_dist, \
-    normalized_blk_hamming_avg, \
+    normalized_blk_hamming_avg
 
 
 class TestHammingDistance(unittest.TestCase):

--- a/set1/challenge06/tests/tests_break_repeat_xor.py
+++ b/set1/challenge06/tests/tests_break_repeat_xor.py
@@ -3,7 +3,12 @@ import os
 import pathlib
 import unittest
 
-from set1.challenge06.break_repeat_xor import *
+from set1.challenge06.break_repeat_xor import \
+    break_repeat_xor
+    build_transposed, \
+    find_keysize, \
+    hamming_dist, \
+    normalized_blk_hamming_avg, \
 
 
 class TestHammingDistance(unittest.TestCase):

--- a/set1/challenge07/tests/tests_ecb_mode.py
+++ b/set1/challenge07/tests/tests_ecb_mode.py
@@ -3,7 +3,7 @@ import unittest
 import sys
 
 from set1.challenge02.fixed_xor import xor
-from set1.challenge07.ecb_mode import *
+from set1.challenge07.ecb_mode import get_block_n, blocks, ECBMode
 
 
 class TestBlocks(unittest.TestCase):

--- a/set1/challenge08/main.py
+++ b/set1/challenge08/main.py
@@ -1,4 +1,3 @@
-from Crypto.Cipher import AES
 import pathlib
 import os
 

--- a/set2/challenge09/tests/tests_pkcs7_padding.py
+++ b/set2/challenge09/tests/tests_pkcs7_padding.py
@@ -1,6 +1,7 @@
 import unittest
 
-from set2.challenge09.pkcs7_padding import *
+from set2.challenge09.pkcs7_padding import pkcs7_pad, pkcs7_unpad, \
+    InvalidPaddingException
 
 
 class TestPKCS7Padding(unittest.TestCase):

--- a/set2/challenge10/cbc_mode.py
+++ b/set2/challenge10/cbc_mode.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import Callable
 
 from set1.challenge02.fixed_xor import xor
 from set1.challenge07.ecb_mode import blocks, BlockCipherMode
@@ -19,7 +18,6 @@ class CBCMode(BlockCipherMode):
             raise ValueError("IV is not same size as blksize")
 
         self.iv = iv
-
 
     def encrypt(self: CBCMode, plaintext: bytes) -> bytes:
         """

--- a/set2/challenge10/tests/tests_cbc_mode.py
+++ b/set2/challenge10/tests/tests_cbc_mode.py
@@ -2,7 +2,8 @@ from Crypto.Cipher import AES
 import unittest
 import sys
 
-from set2.challenge10.cbc_mode import *
+from set1.challenge02.fixed_xor import xor
+from set2.challenge10.cbc_mode import CBCMode
 
 
 class TestCBCMode(unittest.TestCase):

--- a/set2/challenge11/tests/tests_rand_enc.py
+++ b/set2/challenge11/tests/tests_rand_enc.py
@@ -1,6 +1,7 @@
 import unittest
 
-from set2.challenge11.rand_enc import *
+from set2.challenge11.rand_enc import gen_encryption_oracle, is_ecb, \
+    rand_bytes_gen
 
 
 class TestRandEnc(unittest.TestCase):

--- a/set2/challenge12/tests/tests_ecb_decrypt.py
+++ b/set2/challenge12/tests/tests_ecb_decrypt.py
@@ -1,6 +1,7 @@
 import unittest
 
-from set2.challenge12.ecb_decrypt import *
+from set2.challenge12.ecb_decrypt import break_ecb, determine_blksize, \
+    gen_encryption_oracle
 
 
 class TestECBDecrypt(unittest.TestCase):

--- a/set2/challenge13/ecb_cut_paste.py
+++ b/set2/challenge13/ecb_cut_paste.py
@@ -1,9 +1,9 @@
 from Crypto.Cipher import AES
 
 from set1.challenge07.ecb_mode import ECBMode, get_block_n
-from set2.challenge09.pkcs7_padding import *
+from set2.challenge09.pkcs7_padding import pkcs7_pad, pkcs7_unpad
 from set2.challenge11.rand_enc import rand_bytes_gen
-from set2.challenge13.cookie import *
+from set2.challenge13.cookie import decode_cookie, encode_cookie
 
 
 CONSISTENT_KEY = rand_bytes_gen(16)

--- a/set2/challenge13/tests/tests_cookie.py
+++ b/set2/challenge13/tests/tests_cookie.py
@@ -1,6 +1,6 @@
 import unittest
 
-from set2.challenge13.cookie import *
+from set2.challenge13.cookie import decode_cookie, encode_cookie
 
 
 class TestCookie(unittest.TestCase):

--- a/set2/challenge13/tests/tests_ecb_cut_paste.py
+++ b/set2/challenge13/tests/tests_ecb_cut_paste.py
@@ -1,6 +1,7 @@
 import unittest
 
-from set2.challenge13.ecb_cut_paste import *
+from set2.challenge13.ecb_cut_paste import decrypt_profile, encrypt_profile, \
+    profile_for
 
 
 class TestECBCutPaste(unittest.TestCase):

--- a/set2/challenge14/ecb_decrypt.py
+++ b/set2/challenge14/ecb_decrypt.py
@@ -7,7 +7,6 @@ from typing import Callable
 from set1.challenge07.ecb_mode import ECBMode, get_block_n
 from set2.challenge09.pkcs7_padding import pkcs7_pad
 from set2.challenge11.rand_enc import rand_bytes_gen, is_ecb
-from set2.challenge12.ecb_decrypt import determine_blksize
 
 
 CONSISTENT_KEY = rand_bytes_gen(16)

--- a/set2/challenge14/tests/tests_ecb_decrypt.py
+++ b/set2/challenge14/tests/tests_ecb_decrypt.py
@@ -1,7 +1,8 @@
 import unittest
 
 from set2.challenge11.rand_enc import rand_bytes_gen
-from set2.challenge14.ecb_decrypt import *
+from set2.challenge14.ecb_decrypt import break_ecb, determine_randbytes_size, \
+    gen_encryption_oracle
 
 
 class TestECBDecrypt(unittest.TestCase):

--- a/set2/challenge15/main.py
+++ b/set2/challenge15/main.py
@@ -1,4 +1,4 @@
-from set2.challenge09.pkcs7_padding import *
+from set2.challenge09.pkcs7_padding import pkcs7_unpad, InvalidPaddingException
 
 
 def main():

--- a/set2/challenge16/cbc_bitflip.py
+++ b/set2/challenge16/cbc_bitflip.py
@@ -3,7 +3,7 @@ from typing import Callable
 
 from set1.challenge02.fixed_xor import xor
 from set1.challenge07.ecb_mode import blocks
-from set2.challenge09.pkcs7_padding import *
+from set2.challenge09.pkcs7_padding import pkcs7_pad, pkcs7_unpad
 from set2.challenge10.cbc_mode import CBCMode
 from set2.challenge11.rand_enc import rand_bytes_gen
 

--- a/set2/challenge16/tests/tests_cbc_bitflip.py
+++ b/set2/challenge16/tests/tests_cbc_bitflip.py
@@ -1,6 +1,6 @@
 import unittest
 
-from set2.challenge16.cbc_bitflip import *
+from set2.challenge16.cbc_bitflip import gen_encryption_oracle, is_admin
 
 
 class TestCBCBitflip(unittest.TestCase):

--- a/set3/challenge17/cbc_padding.py
+++ b/set3/challenge17/cbc_padding.py
@@ -6,10 +6,10 @@ from typing import Callable, Tuple
 
 from set1.challenge02.fixed_xor import xor
 from set1.challenge07.ecb_mode import blocks
-from set2.challenge09.pkcs7_padding import *
+from set2.challenge09.pkcs7_padding import pkcs7_pad, pkcs7_unpad, \
+    InvalidPaddingException
 from set2.challenge10.cbc_mode import CBCMode
 from set2.challenge11.rand_enc import rand_bytes_gen
-from set2.challenge12.ecb_decrypt import determine_blksize
 
 
 CONSISTENT_KEY = rand_bytes_gen(16)
@@ -26,9 +26,9 @@ def encryption_oracle() -> Tuple[bytes, bytes]:
     plain_strs = (
         b"MDAwMDAwTm93IHRoYXQgdGhlIHBhcnR5IGlzIGp1bXBpbmc=",
         b"MDAwMDAxV2l0aCB0aGUgYmFzcyBraWNrZWQgaW4gYW5kIHRoZSBWZWdhJ3MgYXJlIH" +
-            b"B1bXBpbic=",
+        b"B1bXBpbic=",
         b"MDAwMDAyUXVpY2sgdG8gdGhlIHBvaW50LCB0byB0aGUgcG9pbnQsIG5vIGZha2luZw" +
-            b"==",
+        b"==",
         b"MDAwMDAzQ29va2luZyBNQydzIGxpa2UgYSBwb3VuZCBvZiBiYWNvbg==",
         b"MDAwMDA0QnVybmluZyAnZW0sIGlmIHlvdSBhaW4ndCBxdWljayBhbmQgbmltYmxl",
         b"MDAwMDA1SSBnbyBjcmF6eSB3aGVuIEkgaGVhciBhIGN5bWJhbA==",

--- a/set3/challenge17/tests/tests_cbc_padding.py
+++ b/set3/challenge17/tests/tests_cbc_padding.py
@@ -1,8 +1,14 @@
+from Crypto.Cipher import AES
 import unittest
 import sys
 
 from set2.challenge10.cbc_mode import CBCMode
-from set3.challenge17.cbc_padding import *
+from set3.challenge17.cbc_padding import \
+    CONSISTENT_KEY, \
+    break_cbc_single_blk, \
+    encryption_oracle, \
+    get_byte_n, \
+    valid_padding
 
 
 class TestCBCPadding(unittest.TestCase):
@@ -15,7 +21,7 @@ class TestCBCPadding(unittest.TestCase):
     def test_valid_padding_padding_is_invalid(self):
         encrypted, iv = encryption_oracle()
         encrypted = encrypted[:-1] + \
-            ((encrypted[-1]+1)%256).to_bytes(1, byteorder=sys.byteorder)
+            ((encrypted[-1]+1) % 256).to_bytes(1, byteorder=sys.byteorder)
 
         self.assertFalse(valid_padding(encrypted, iv))
 

--- a/set3/challenge18/tests/tests_ctr_mode.py
+++ b/set3/challenge18/tests/tests_ctr_mode.py
@@ -1,8 +1,7 @@
 from Crypto.Cipher import AES
 import unittest
-import sys
 
-from set3.challenge18.ctr_mode import *
+from set3.challenge18.ctr_mode import CTRMode
 
 
 class TestCTRMode(unittest.TestCase):
@@ -76,10 +75,12 @@ class TestCTRMode(unittest.TestCase):
                      b"r sit amet, cons"
                      b"ectetur adipisci"
                      b"ng elitAAAAAAAAA")
-        expected_encrypted = (b":\xbe\xb9.\xc2\x82/\x92\x90\xdan}\x08|\xaf\x1d"
-                              b"\xa0\xcc\x1f\xb5\xecMs\xb3\xaa\xae3\xb3\xcc\x81\x1dk"
-                              b"H\xc3\xfa\xaee\x0eEk\xa2\xbe\xdeV\xdb\x8f\xe7\xa4"
-                              b"\xaf\xe7\x8bP%\x93\x1a\x14\x90\r'&\x88.\xe4\xf1")
+        expected_encrypted = (
+            b":\xbe\xb9.\xc2\x82/\x92\x90\xdan}\x08|\xaf\x1d"
+            b"\xa0\xcc\x1f\xb5\xecMs\xb3\xaa\xae3\xb3\xcc\x81\x1dk"
+            b"H\xc3\xfa\xaee\x0eEk\xa2\xbe\xdeV\xdb\x8f\xe7\xa4"
+            b"\xaf\xe7\x8bP%\x93\x1a\x14\x90\r'&\x88.\xe4\xf1"
+        )
 
         encrypted = ctr.encrypt(plaintext)
 


### PR DESCRIPTION
Whole bunch of flake8 fixes.
Mostly being more explicit with imports instead of using `import *` to allow linter to track imports.